### PR TITLE
feat: Add province and municipality level dashboard charts

### DIFF
--- a/app.log
+++ b/app.log
@@ -1,0 +1,8 @@
+ * Serving Flask app 'app'
+ * Debug mode: on
+[31m[1mWARNING: This is a development server. Do not use it in a production deployment. Use a production WSGI server instead.[0m
+ * Running on all addresses (0.0.0.0)
+ * Running on http://127.0.0.1:5000
+ * Running on http://192.168.0.2:5000
+[33mPress CTRL+C to quit[0m
+ * Restarting with stat

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -40,6 +40,21 @@
     </div>
 </div>
 
+<div class="row mt-4">
+    <div class="col-lg-12">
+        <div class="card mb-4">
+            <div class="card-header">
+                <i class="fas fa-chart-bar me-1"></i>
+                Average Score by Province and Section (Click a province to drill down)
+            </div>
+            <div class="card-body" style="height: 600px;">
+                <canvas id="provinceScoresChart"
+                        data-chart-data='{{ province_chart_data|safe }}'></canvas>
+            </div>
+        </div>
+    </div>
+</div>
+
 <!-- Chart.js CDN -->
 <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 
@@ -97,6 +112,70 @@ document.addEventListener('DOMContentLoaded', function () {
             }
         }
     });
+
+    // --- Province Scores Chart (Horizontal Grouped Bar) ---
+    const provinceScoresCanvas = document.getElementById('provinceScoresChart');
+    if (provinceScoresCanvas) {
+        try {
+            const provinceChartData = JSON.parse(provinceScoresCanvas.dataset.chartData);
+            if (provinceChartData && provinceChartData.labels && provinceChartData.labels.length > 0) {
+                new Chart(provinceScoresCanvas.getContext('2d'), {
+                    type: 'bar',
+                    data: provinceChartData,
+                    options: {
+                        indexAxis: 'y',
+                        responsive: true,
+                        maintainAspectRatio: false,
+                        scales: {
+                            x: {
+                                beginAtZero: true,
+                                max: 4,
+                                stacked: false
+                            },
+                            y: {
+                                stacked: false,
+                                ticks: {
+                                    autoSkip: false
+                                }
+                            }
+                        },
+                        plugins: {
+                            legend: {
+                                position: 'top',
+                            },
+                            title: {
+                                display: true,
+                                text: 'Average Scores by Province'
+                            },
+                            tooltip: {
+                                mode: 'index',
+                                intersect: false
+                            }
+                        },
+                        onClick: function(event, elements) {
+                            if (elements.length > 0) {
+                                const chart = this;
+                                const elementIndex = elements[0].index;
+                                const province = chart.data.labels[elementIndex];
+                                window.location.href = '/dashboard/province/' + encodeURIComponent(province);
+                            }
+                        }
+                    }
+                });
+            } else {
+                const ctx = provinceScoresCanvas.getContext('2d');
+                ctx.font = "16px Arial";
+                ctx.textAlign = "center";
+                ctx.fillText("No data available to display for this chart.", provinceScoresCanvas.width / 2, 50);
+            }
+        } catch (e) {
+            console.error("Error parsing province chart data:", e);
+            const ctx = provinceScoresCanvas.getContext('2d');
+            ctx.font = "16px Arial";
+            ctx.textAlign = "center";
+            ctx.fillText("Error loading chart data.", provinceScoresCanvas.width / 2, 50);
+        }
+    }
 });
 </script>
 {% endblock %}

--- a/templates/province_dashboard.html
+++ b/templates/province_dashboard.html
@@ -1,0 +1,85 @@
+{% extends 'base.html' %}
+
+{% block title %}Dashboard - {{ province_name }}{% endblock %}
+
+{% block content %}
+<div class="d-flex justify-content-between align-items-center mb-4">
+    <h1>Dashboard: {{ province_name }}</h1>
+    <a href="{{ url_for('dashboard') }}" class="btn btn-secondary">Back to Main Dashboard</a>
+</div>
+
+<div class="row mt-4">
+    <div class="col-lg-12">
+        <div class="card mb-4">
+            <div class="card-header">
+                <i class="fas fa-chart-bar me-1"></i>
+                Average Score by Municipality and Section
+            </div>
+            <div class="card-body" style="height: 600px;">
+                <canvas id="municipalityScoresChart"
+                        data-chart-data='{{ municipality_chart_data|safe }}'></canvas>
+            </div>
+        </div>
+    </div>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+    const municipalityScoresCanvas = document.getElementById('municipalityScoresChart');
+    if (municipalityScoresCanvas) {
+        try {
+            const municipalityChartData = JSON.parse(municipalityScoresCanvas.dataset.chartData);
+            if (municipalityChartData && municipalityChartData.labels && municipalityChartData.labels.length > 0) {
+                new Chart(municipalityScoresCanvas.getContext('2d'), {
+                    type: 'bar',
+                    data: municipalityChartData,
+                    options: {
+                        indexAxis: 'y',
+                        responsive: true,
+                        maintainAspectRatio: false,
+                        scales: {
+                            x: {
+                                beginAtZero: true,
+                                max: 4,
+                                stacked: false
+                            },
+                            y: {
+                                stacked: false,
+                                ticks: {
+                                    autoSkip: false
+                                }
+                            }
+                        },
+                        plugins: {
+                            legend: {
+                                position: 'top',
+                            },
+                            title: {
+                                display: true,
+                                text: 'Average Scores by Municipality'
+                            },
+                            tooltip: {
+                                mode: 'index',
+                                intersect: false
+                            }
+                        }
+                    }
+                });
+            } else {
+                const ctx = municipalityScoresCanvas.getContext('2d');
+                ctx.font = "16px Arial";
+                ctx.textAlign = "center";
+                ctx.fillText("No data available to display for this chart.", municipalityScoresCanvas.width / 2, 50);
+            }
+        } catch (e) {
+            console.error("Error parsing municipality chart data:", e);
+            const ctx = municipalityScoresCanvas.getContext('2d');
+            ctx.font = "16px Arial";
+            ctx.textAlign = "center";
+            ctx.fillText("Error loading chart data.", municipalityScoresCanvas.width / 2, 50);
+        }
+    }
+});
+</script>
+{% endblock %}


### PR DESCRIPTION
This commit introduces a new bar chart to the main dashboard that displays the average assessment scores grouped by province and section.

Key features include:
- A new horizontal grouped bar chart on the main dashboard showing average scores per province.
- Drill-down functionality: clicking on a province bar navigates to a new view showing average scores by municipality for that province.
- A new route `/dashboard/province/<province_name>` and a corresponding template to display the municipality-level data.
- Dynamic color generation for chart sections to improve visual distinction.